### PR TITLE
Use normalized icon for edit dialog and for reset purposes

### DIFF
--- a/src/com/android/launcher3/EditDropTarget.java
+++ b/src/com/android/launcher3/EditDropTarget.java
@@ -50,19 +50,16 @@ public class EditDropTarget extends ButtonDropTarget {
 
     @Override
     public void completeDrop(DragObject d) {
-        Bitmap bitmap = null;
         ComponentName componentName = null;
         ItemInfo info = d.dragInfo;
         if (info instanceof AppInfo) {
             componentName = ((AppInfo) info).componentName;
-            bitmap = ((AppInfo) info).iconBitmap;
         } else if (info instanceof ShortcutInfo) {
             componentName = ((ShortcutInfo) info).intent.getComponent();
-            bitmap = ((ShortcutInfo) info).getIcon(LauncherAppState.getInstance().getIconCache());
         }
 
-        if (bitmap != null && componentName != null) {
-            mLauncher.startEdit(bitmap, info, componentName);
+        if (componentName != null) {
+            mLauncher.startEdit(info, componentName);
         }
     }
 }

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -4477,7 +4477,7 @@ public class Launcher extends Activity
         return createAppDragInfo(appLaunchIntent, user);
     }
 
-    protected void startEdit(final Bitmap bm, final ItemInfo info, final ComponentName component) {
+    protected void startEdit(final ItemInfo info, final ComponentName component) {
         LauncherActivityInfoCompat app = LauncherAppsCompat.getInstance(this)
                 .resolveActivity(info.getIntent(), info.user);
         mIconPackView = getLayoutInflater().inflate(R.layout.edit_dialog, null);
@@ -4487,8 +4487,8 @@ public class Launcher extends Activity
         mEditText.setSelection(mEditText.getText().length());
 
         final Resources res = getResources();
-        Bitmap defaultIcon = mIconsHandler.getDrawableIconForPackage(component);
-        Drawable icon = new BitmapDrawable(res, defaultIcon);
+		final Bitmap bm = Utilities.getEditIconBitmap(this, mIconCache, info);
+		final Drawable icon = new BitmapDrawable(getResources(), bm);
         mPackageIcon.setImageBitmap(bm);
 
         final int popupWidth = getResources().getDimensionPixelSize(R.dimen.edit_dialog_min_width);
@@ -4534,8 +4534,7 @@ public class Launcher extends Activity
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
-                            mIconCache.addCustomInfoToDataBase(new BitmapDrawable(res, bm),
-                                    info, mEditText.getText());
+                            mIconCache.addCustomInfoToDataBase(icon, info, mEditText.getText());
                             mIconPackDialog.dismiss();
                         }
                 });

--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -416,7 +416,15 @@ public final class Utilities {
             return bitmap;
         }
     }
-
+	
+	//get normalized icon for edit icon dialog and for reset purposes
+	static Bitmap getEditIconBitmap(Context context, IconCache mIconCache, ItemInfo info) {
+ 
+		Drawable defaultIcon = mIconCache.getDefaultIcon(info);
+ 
+ 		return createBadgedIconBitmap(defaultIcon, info.user, context);
+ 	}
+	
     /**
      * Given a coordinate relative to the descendant, find the coordinate in a parent view's
      * coordinates.


### PR DESCRIPTION
getDrawableIconForPackage(component) gets the default app icon not normalized. So if You reset an app's icon You'll get a bigger one than the others.
This way You'll get the "badged"icon that is the one used for the apps.